### PR TITLE
Update nuget references to newer version of IdentityServer3 (2.4.0)

### DIFF
--- a/source/Host/Config/Clients.cs
+++ b/source/Host/Config/Clients.cs
@@ -1,8 +1,5 @@
-﻿using System;
+﻿using IdentityServer3.Core.Models;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using Thinktecture.IdentityServer.Core.Models;
 
 namespace Host.Config
 {

--- a/source/Host/Config/Scopes.cs
+++ b/source/Host/Config/Scopes.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using Thinktecture.IdentityServer.Core;
-using Thinktecture.IdentityServer.Core.Models;
+﻿using IdentityServer3.Core;
+using IdentityServer3.Core.Models;
+using System.Collections.Generic;
 
 namespace Host.Config
 {
@@ -47,7 +47,7 @@ namespace Host.Config
                         Type = ScopeType.Resource,
                         Emphasize = true,
                         ShowInDiscoveryDocument = false,
-                        
+
                         Claims = new List<ScopeClaim>
                         {
                             new ScopeClaim(Constants.ClaimTypes.Name),
@@ -55,6 +55,6 @@ namespace Host.Config
                         }
                     }
                 };
-        }  
+        }
     }
 }

--- a/source/Host/Config/Users.cs
+++ b/source/Host/Config/Users.cs
@@ -1,10 +1,7 @@
-﻿using System;
+﻿using IdentityServer3.Core;
+using IdentityServer3.Core.Services.InMemory;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Web;
-using Thinktecture.IdentityServer.Core;
-using Thinktecture.IdentityServer.Core.Services.InMemory;
 
 namespace Host.Config
 {
@@ -14,7 +11,7 @@ namespace Host.Config
         {
             return new List<InMemoryUser>
             {
-                new InMemoryUser{Subject = "1", Username = "Admin", Password = "secret", 
+                new InMemoryUser{Subject = "1", Username = "Admin", Password = "secret",
                     Claims = new Claim[]
                     {
                         new Claim(Constants.ClaimTypes.GivenName, "Admin"),

--- a/source/Host/Host.csproj
+++ b/source/Host/Host.csproj
@@ -19,6 +19,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +39,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IdentityServer3, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.4.0\lib\net45\IdentityServer3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -70,10 +75,6 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="Thinktecture.IdentityModel.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Thinktecture.IdentityModel.Core.1.4.0\lib\net45\Thinktecture.IdentityModel.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.4.0\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/source/Host/Startup.cs
+++ b/source/Host/Startup.cs
@@ -1,11 +1,10 @@
-﻿using System.Collections.Generic;
-using Host.Config;
+﻿using Host.Config;
 using IdentityServer.SiteFinity.Configuration;
 using IdentityServer.SiteFinity.Models;
 using IdentityServer.SiteFinity.Services;
+using IdentityServer3.Core.Configuration;
 using Owin;
-using Thinktecture.IdentityServer.Core.Configuration;
-using Thinktecture.IdentityServer.Core.Logging;
+using System.Collections.Generic;
 
 namespace Host
 {
@@ -13,26 +12,24 @@ namespace Host
     {
         public void Configuration(IAppBuilder app)
         {
-            LogProvider.SetCurrentLogProvider(new DiagnosticsTraceLogProvider());
-
             app.Map("/core", coreApp =>
-            {
-                var factory = InMemoryFactory.Create(
-                    users: Users.Get(),
-                    clients: Clients.Get(),
-                    scopes: Scopes.Get());
+         {
+             var factory = new IdentityServerServiceFactory()
+    .UseInMemoryUsers(Users.Get())
+    .UseInMemoryClients(Clients.Get())
+    .UseInMemoryScopes(Scopes.Get());
 
-                var options = new IdentityServerOptions
-                {
-                    SiteName = "IdentityServer3 with SiteFinity",
+             var options = new IdentityServerOptions
+             {
+                 SiteName = "IdentityServer3 with SiteFinity",
 
-                    SigningCertificate = Certificate.Get(),
-                    Factory = factory,
-                    PluginConfiguration = ConfigurePlugins,
-                };
+                 SigningCertificate = Certificate.Get(),
+                 Factory = factory,
+                 PluginConfiguration = ConfigurePlugins,
+             };
 
-                coreApp.UseIdentityServer(options);
-            });
+             coreApp.UseIdentityServer(options);
+         });
         }
 
         private void ConfigurePlugins(IAppBuilder pluginApp, IdentityServerOptions options)

--- a/source/Host/packages.config
+++ b/source/Host/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="IdentityServer3" version="2.4.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Thinktecture.IdentityModel.Core" version="1.4.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.4.0" targetFramework="net45" />
 </packages>

--- a/source/SiteFinityPlugin/Configuration/Hosting/AutofacConfig.cs
+++ b/source/SiteFinityPlugin/Configuration/Hosting/AutofacConfig.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using Autofac;
+﻿using Autofac;
 using Autofac.Integration.WebApi;
 using IdentityServer.SiteFinity.ResponseHandling;
 using IdentityServer.SiteFinity.Token;
 using IdentityServer.SiteFinity.Utilities;
 using IdentityServer.SiteFinity.Validation;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Logging;
+using IdentityServer3.Core.Services;
 using Microsoft.Owin;
-using Thinktecture.IdentityServer.Core.Configuration;
-using Thinktecture.IdentityServer.Core.Logging;
-using Thinktecture.IdentityServer.Core.Services;
+using System;
 
 namespace IdentityServer.SiteFinity.Configuration.Hosting
 {

--- a/source/SiteFinityPlugin/Configuration/Hosting/AutofacDependencyResolver.cs
+++ b/source/SiteFinityPlugin/Configuration/Hosting/AutofacDependencyResolver.cs
@@ -1,5 +1,5 @@
 ﻿using Autofac;
-using Thinktecture.IdentityServer.Core.Services;
+using IdentityServer3.Core.Services;
 
 namespace IdentityServer.SiteFinity.Configuration.Hosting
 {

--- a/source/SiteFinityPlugin/Configuration/Hosting/LibLogTraceListener.cs
+++ b/source/SiteFinityPlugin/Configuration/Hosting/LibLogTraceListener.cs
@@ -1,5 +1,5 @@
-﻿using System.Diagnostics;
-using Thinktecture.IdentityServer.Core.Logging;
+﻿using IdentityServer3.Core.Logging;
+using System.Diagnostics;
 
 namespace IdentityServer.SiteFinity.Configuration.Hosting
 {

--- a/source/SiteFinityPlugin/Configuration/Hosting/LogProviderExceptionLogger.cs
+++ b/source/SiteFinityPlugin/Configuration/Hosting/LogProviderExceptionLogger.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading;
+﻿using IdentityServer3.Core.Logging;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http.ExceptionHandling;
-using Thinktecture.IdentityServer.Core.Logging;
 
 namespace IdentityServer.SiteFinity.Configuration.Hosting
 {

--- a/source/SiteFinityPlugin/Configuration/RequestResponseLogger.cs
+++ b/source/SiteFinityPlugin/Configuration/RequestResponseLogger.cs
@@ -1,7 +1,7 @@
-﻿using System.Net.Http;
+﻿using IdentityServer3.Core.Logging;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Thinktecture.IdentityServer.Core.Logging;
 
 namespace IdentityServer.SiteFinity.Configuration
 {
@@ -19,7 +19,7 @@ namespace IdentityServer.SiteFinity.Configuration
                 Body = await request.Content.ReadAsStringAsync()
             };
 
-            Logger.DebugFormat("HTTP Request\n{0}", LogSerializer.Serialize(reqLog));
+            // Logger.DebugFormat("HTTP Request\n{0}", LogSerializer.Serialize(reqLog));
 
             var response = await base.SendAsync(request, cancellationToken);
 
@@ -37,7 +37,7 @@ namespace IdentityServer.SiteFinity.Configuration
                 Body = body
             };
 
-            Logger.DebugFormat("HTTP Response\n{0}", LogSerializer.Serialize(respLog));
+            //   Logger.DebugFormat("HTTP Response\n{0}", LogSerializer.Serialize(respLog));
 
             return response;
         }

--- a/source/SiteFinityPlugin/Configuration/SiteFinityPluginOptions.cs
+++ b/source/SiteFinityPlugin/Configuration/SiteFinityPluginOptions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Thinktecture.IdentityServer.Core.Configuration;
+﻿using IdentityServer3.Core.Configuration;
+using System;
 
 namespace IdentityServer.SiteFinity.Configuration
 {
@@ -49,7 +49,7 @@ namespace IdentityServer.SiteFinity.Configuration
         public SiteFinityPluginOptions(IdentityServerOptions options) : this()
         {
             if (options == null) throw new ArgumentNullException("options");
-            
+
             IdentityServerOptions = options;
             this.Factory = new SiteFinityServiceFactory(options.Factory);
         }
@@ -70,7 +70,7 @@ namespace IdentityServer.SiteFinity.Configuration
             {
                 throw new ArgumentNullException("Factory not configured");
             }
-            
+
             if (IdentityServerOptions == null)
             {
                 throw new ArgumentNullException("Options not configured");

--- a/source/SiteFinityPlugin/Configuration/SiteFinityServiceFactory.cs
+++ b/source/SiteFinityPlugin/Configuration/SiteFinityServiceFactory.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using IdentityServer.SiteFinity.Services;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Logging;
+using IdentityServer3.Core.Services;
+using System;
 using System.Collections.Generic;
-using IdentityServer.SiteFinity.Services;
-using Thinktecture.IdentityServer.Core.Configuration;
-using Thinktecture.IdentityServer.Core.Logging;
-using Thinktecture.IdentityServer.Core.Services;
 
 namespace IdentityServer.SiteFinity.Configuration
 {

--- a/source/SiteFinityPlugin/Models/SignInValidationLog.cs
+++ b/source/SiteFinityPlugin/Models/SignInValidationLog.cs
@@ -1,5 +1,5 @@
 ﻿using IdentityServer.SiteFinity.Validation;
-using Thinktecture.IdentityServer.Core.Extensions;
+using IdentityServer3.Core.Extensions;
 
 namespace IdentityServer.SiteFinity.Models
 {

--- a/source/SiteFinityPlugin/SiteFinityController.cs
+++ b/source/SiteFinityPlugin/SiteFinityController.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.ComponentModel;
-using System.Net;
-using System.Net.Http;
-using System.Security.Claims;
-using System.Threading.Tasks;
-using System.Web.Http;
-using System.Web.Http.Results;
-using IdentityServer.SiteFinity.Configuration.Hosting;
+﻿using IdentityServer.SiteFinity.Configuration.Hosting;
 using IdentityServer.SiteFinity.ResponseHandling;
 using IdentityServer.SiteFinity.Services;
 using IdentityServer.SiteFinity.Utilities;
 using IdentityServer.SiteFinity.Validation;
-using Thinktecture.IdentityServer.Core;
-using Thinktecture.IdentityServer.Core.Extensions;
-using Thinktecture.IdentityServer.Core.Logging;
-using Thinktecture.IdentityServer.Core.Models;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Extensions;
+using IdentityServer3.Core.Logging;
+using IdentityServer3.Core.Models;
+using System;
+using System.ComponentModel;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Web.Http;
 
 namespace IdentityServer.SiteFinity
 {
@@ -39,7 +37,7 @@ namespace IdentityServer.SiteFinity
         /// <param name="validator">The validator class</param>
         /// <param name="signInResponseGenerator">The response generator</param>
         /// <param name="httpUtility">The utily class used for url encoding and url decoding</param>
-        public SiteFinityController(SignInValidator validator, SignInResponseGenerator signInResponseGenerator,HttpUtility httpUtility)
+        public SiteFinityController(SignInValidator validator, SignInResponseGenerator signInResponseGenerator, HttpUtility httpUtility)
         {
             _validator = validator;
             _signInResponseGenerator = signInResponseGenerator;
@@ -79,11 +77,11 @@ namespace IdentityServer.SiteFinity
                 return BadRequest(result.Error);
             }
 
-            var responseMessage = await _signInResponseGenerator.GenerateResponseAsync(message, result,Request);
-            
+            var responseMessage = await _signInResponseGenerator.GenerateResponseAsync(message, result, Request);
+
             return responseMessage;
 
-            
+
         }
 
         private IHttpActionResult RedirectToLogin()

--- a/source/SiteFinityPlugin/SiteFinityPlugin.csproj
+++ b/source/SiteFinityPlugin/SiteFinityPlugin.csproj
@@ -40,6 +40,10 @@
       <HintPath>..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="IdentityServer3, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.4.0\lib\net45\IdentityServer3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -78,10 +82,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="Thinktecture.IdentityModel.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Thinktecture.IdentityModel.Core.1.4.0\lib\net45\Thinktecture.IdentityModel.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.5.0\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/source/SiteFinityPlugin/Validation/SignInValidator.cs
+++ b/source/SiteFinityPlugin/Validation/SignInValidator.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using IdentityServer.SiteFinity.Services;
+using IdentityServer3.Core.Logging;
+using System;
 using System.ComponentModel;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityServer.SiteFinity.Models;
-using IdentityServer.SiteFinity.Services;
-using Thinktecture.IdentityServer.Core.Logging;
 
 namespace IdentityServer.SiteFinity.Validation
 {
@@ -47,7 +46,7 @@ namespace IdentityServer.SiteFinity.Validation
             {
                 if (!subject.Identity.IsAuthenticated)
                 {
-                    LogError("Signout requested for user not signed in.",result);
+                    LogError("Signout requested for user not signed in.", result);
 
                     return new SignInValidationResult
                     {
@@ -67,7 +66,7 @@ namespace IdentityServer.SiteFinity.Validation
                 return result;
             }
 
-            
+
 
             var rp = await _siteFinityRelyingPartyService.GetByRealmAsync(message.Realm);
 
@@ -88,7 +87,7 @@ namespace IdentityServer.SiteFinity.Validation
             {
                 if (!string.IsNullOrWhiteSpace(rp.ReplyUrl))
                 {
-                    result.ReplyUrl = rp.ReplyUrl; 
+                    result.ReplyUrl = rp.ReplyUrl;
                 }
                 else
                 {
@@ -117,14 +116,14 @@ namespace IdentityServer.SiteFinity.Validation
 
         private void LogSuccess(SignInValidationResult result)
         {
-            var log = LogSerializer.Serialize(new SignInValidationLog(result));
-            Logger.InfoFormat("End WS-Federation signin request validation\n{0}", log);
+            // var log = LogSerializer.Serialize(new SignInValidationLog(result));
+            // Logger.InfoFormat("End WS-Federation signin request validation\n{0}", log);
         }
 
         private void LogError(string message, SignInValidationResult result)
         {
-            var log = LogSerializer.Serialize(new SignInValidationLog(result));
-            Logger.ErrorFormat("{0}\n{1}", message, log);
+            // var log = LogSerializer.Serialize(new SignInValidationLog(result));
+            // Logger.ErrorFormat("{0}\n{1}", message, log);
         }
 
         private string GetIssuerFromRequestUri(string absoluteUri)

--- a/source/SiteFinityPlugin/packages.config
+++ b/source/SiteFinityPlugin/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
+  <package id="IdentityServer3" version="2.4.0" targetFramework="net45" />
   <package id="ilmerge" version="2.14.1208" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
@@ -11,5 +12,4 @@
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Thinktecture.IdentityModel.Core" version="1.4.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I attempted to use your project with a newer version of IdentityServer (https://github.com/IdentityServer/IdentityServer3) but the current version of your Sitefinity plugin references the older Thinktecture.IdentityServer3 library.

This commit updates to the newer library and version of IdentityServer3 (2.4.0). If you think this would be useful to merge with your project please feel free to do so with my thanks and gratitude for your work on this project.
